### PR TITLE
Use TokenHandler abstraction

### DIFF
--- a/src/main/java/no/nav/foreldrepenger/lookup/ws/OnBehalfOfOutInterceptor.java
+++ b/src/main/java/no/nav/foreldrepenger/lookup/ws/OnBehalfOfOutInterceptor.java
@@ -1,16 +1,14 @@
 package no.nav.foreldrepenger.lookup.ws;
 
+import static javax.xml.XMLConstants.FEATURE_SECURE_PROCESSING;
 import static no.nav.foreldrepenger.lookup.EnvUtil.CONFIDENTIAL;
+import static org.apache.cxf.rt.security.SecurityConstants.STS_TOKEN_ON_BEHALF_OF;
+import static org.springframework.beans.factory.config.ConfigurableBeanFactory.SCOPE_PROTOTYPE;
 
 import java.io.IOException;
 import java.io.StringReader;
 import java.util.Base64;
-import java.util.List;
-import java.util.Objects;
 
-import javax.inject.Inject;
-import javax.xml.XMLConstants;
-import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 
@@ -18,100 +16,58 @@ import org.apache.cxf.interceptor.Fault;
 import org.apache.cxf.message.Message;
 import org.apache.cxf.phase.AbstractPhaseInterceptor;
 import org.apache.cxf.phase.Phase;
-import org.apache.cxf.rt.security.SecurityConstants;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.config.ConfigurableBeanFactory;
 import org.springframework.context.annotation.Scope;
 import org.springframework.stereotype.Component;
-import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
 
-import no.nav.security.oidc.context.OIDCValidationContext;
-import no.nav.security.oidc.context.TokenContext;
-import no.nav.security.spring.oidc.SpringOIDCRequestContextHolder;
-import no.nav.security.spring.oidc.validation.interceptor.OIDCUnauthorizedException;
+import no.nav.foreldrepenger.lookup.TokenHandler;
 
 @Component
-@Scope(ConfigurableBeanFactory.SCOPE_PROTOTYPE)
+@Scope(SCOPE_PROTOTYPE)
 public class OnBehalfOfOutInterceptor extends AbstractPhaseInterceptor<Message> {
     private static final Logger LOG = LoggerFactory.getLogger(OnBehalfOfOutInterceptor.class);
 
-    @Inject
-    private SpringOIDCRequestContextHolder oidcRequestContextHolder;
+    private static final String OIDC_TOKEN_TYPE = "urn:ietf:params:oauth:token-type:jwt";
+    private final TokenHandler tokenHandler;
 
-    public enum TokenType {
-        OIDC("urn:ietf:params:oauth:token-type:jwt");
-        public String valueType;
-
-        TokenType(String valueType) {
-            this.valueType = valueType;
-        }
-    }
-
-    public OnBehalfOfOutInterceptor() {
+    public OnBehalfOfOutInterceptor(TokenHandler tokenHandler) {
         super(Phase.SETUP);
+        this.tokenHandler = tokenHandler;
     }
 
     @Override
     public void handleMessage(Message message) throws Fault {
-
-        LOG.debug("looking up OnBehalfOfToken from SpringOIDCRequestContextHolder.");
-        String token = getTokenFromFirstIssuerInValidationContext();
-
-        if (token != null) {
-            byte[] tokenBytes = token.getBytes();
-            String wrappedToken = wrapTokenForTransport(tokenBytes, TokenType.OIDC);
-            message.put(SecurityConstants.STS_TOKEN_ON_BEHALF_OF, createOnBehalfOfElement(wrappedToken));
-        }
-        else {
-            LOG.warn("could not find OnBehalfOfToken token in requestcontext.");
-            throw new OIDCUnauthorizedException("no OIDC token found when attempting to invoke sts.");
-        }
+        LOG.debug("Slår opp OnBehalfOfToken");
+        String token = tokenHandler.getToken();
+        LOG.debug(CONFIDENTIAL, "Fant token {}", token);
+        message.put(STS_TOKEN_ON_BEHALF_OF, createOnBehalfOfElement(token));
     }
 
-    private String getTokenFromFirstIssuerInValidationContext() {
-        OIDCValidationContext context = oidcRequestContextHolder.getOIDCValidationContext();
-        List<String> issuers = context.getIssuers();
-        if (context != null && issuers != null) {
-            String issuerName = issuers.stream().filter(Objects::nonNull).findFirst().orElse(null);
-            LOG.debug("getting first issuer in validation context: " + issuerName);
-            TokenContext token = context.getToken(issuerName);
-            LOG.debug(CONFIDENTIAL, "found token: " + token);
-            return token != null ? token.getIdToken() : null;
-        }
-        LOG.warn("no issuers found in oidcvalidationcontext. returning null");
-        return null;
-    }
-
-    private String wrapTokenForTransport(byte[] token, TokenType tokenType) {
-        switch (tokenType) {
-        case OIDC:
-            return wrapWithBinarySecurityToken(token, tokenType.valueType);
-        default:
-            throw new RuntimeException("unsupported token type:" + tokenType);
-        }
-    }
-
-    private static Element createOnBehalfOfElement(String content) {
+    private static Element createOnBehalfOfElement(String token) {
         try {
+            String content = wrapWithBinarySecurityToken(token.getBytes());
             DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
             factory.setNamespaceAware(true);
-            factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
-            DocumentBuilder builder = factory.newDocumentBuilder();
-            Document document = builder.parse(new InputSource(new StringReader(content)));
-            return document.getDocumentElement();
+            factory.setFeature(FEATURE_SECURE_PROCESSING, true);
+            return factory.newDocumentBuilder().parse(new InputSource(new StringReader(content))).getDocumentElement();
         } catch (ParserConfigurationException | SAXException | IOException e) {
             throw new RuntimeException(e);
         }
     }
 
-    private static String wrapWithBinarySecurityToken(byte[] token, String valueType) {
+    private static String wrapWithBinarySecurityToken(byte[] token) {
         String base64encodedToken = Base64.getEncoder().encodeToString(token);
         return "<wsse:BinarySecurityToken xmlns:wsse=\"http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd\""
                 + " EncodingType=\"http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-soap-message-security-1.0#Base64Binary\""
-                + " ValueType=\"" + valueType + "\" >" + base64encodedToken + "</wsse:BinarySecurityToken>";
+                + " ValueType=\"" + OIDC_TOKEN_TYPE + "\" >" + base64encodedToken + "</wsse:BinarySecurityToken>";
+    }
+
+    @Override
+    public String toString() {
+        return getClass().getSimpleName() + " [tokenHandler=" + tokenHandler + "]";
     }
 }


### PR DESCRIPTION
 This allows us to remove some ugly code navigating the OIDCRequestContextHolder. This also simplifies error handling since the exception (ForbiddenException) thrown by the TokenHandler  in the case of a missing token can be propagated all the way up to the  CommonControllerErrorHandler, where it will be translated to a 403. Removed a pointless enum with only one legal value, as well as some  logging improvements and inlining of only-once temporary variables. Looks prettier now :-)