### PR TITLE
Endret InnsynJournal_v2 url fra joark (WAS) til dokarkiv (NAIS)

### DIFF
--- a/dev-fss.json
+++ b/dev-fss.json
@@ -4,7 +4,7 @@
   "env": {
    "SAK_SAKER_URL": "https://sak-q1.nais.preprod.local/api/v1/saker",
    "VIRKSOMHET_FORELDREPENGESAK_V1_ENDPOINTURL": "https://fpsak-q1.nais.preprod.local/fpsak/tjenester/sak/finnSak/v1",  
-   "INNSYNJOURNAL_V2_ENDPOINTURL": "https://wasapp-q1.adeo.no/joark/InnsynJournal/v2",
+   "INNSYNJOURNAL_V2_ENDPOINTURL": "https://dokarkiv-q1.nais.preprod.local/services/innsynjournal/v2",
    "AKTOER_V2_ENDPOINTURL": "https://app-q1.adeo.no/aktoerregister/ws/Aktoer/v2",
    "VIRKSOMHET_PERSON_V3_ENDPOINTURL": "https://wasapp-q1.adeo.no/tpsws/ws/Person/v3",  
    "SECURITYTOKENSERVICE_URL": "https://sts-q1.preprod.local/SecurityTokenServiceProvider/",

--- a/prod-fss.json
+++ b/prod-fss.json
@@ -4,7 +4,7 @@
   "env": {
    "SAK_SAKER_URL": "https://sak.nais.adeo.no/api/v1/saker",
    "VIRKSOMHET_FORELDREPENGESAK_V1_ENDPOINTURL": "https://fpsak.nais.adeo.no/fpsak/tjenester/sak/finnSak/v1",  
-   "INNSYNJOURNAL_V2_ENDPOINTURL": "https://wasapp.adeo.no/joark/InnsynJournal/v2",
+   "INNSYNJOURNAL_V2_ENDPOINTURL": "https://dokarkiv.nais.adeo.no/services/innsynjournal/v2",
    "AKTOER_V2_ENDPOINTURL": "https://app.adeo.no/aktoerregister/ws/Aktoer/v2",
    "VIRKSOMHET_PERSON_V3_ENDPOINTURL": "https://wasapp.adeo.no/tpsws/ws/Person/v3",  
    "SECURITYTOKENSERVICE_URL": "https://sts.adeo.no/SecurityTokenServiceProvider/",


### PR DESCRIPTION
Hei

Vi har flyttet InnsynJournal_v2 tjenesten til dokarkiv på NAIS. Tjenesten er identisk og den har vært i bruk i produksjon siden 12. mars i år.

Vi ser at dere har URLer mot joark og ønsker få disse oppdatert. Vi kommer til å sanere tjenesten på joark så snart alle NAIS konsumenter har tatt i bruk ny url.
